### PR TITLE
✨ Feature/victory losing conditions multiplayer solo

### DIFF
--- a/client/engine/InitRegistryComponent.cpp
+++ b/client/engine/InitRegistryComponent.cpp
@@ -44,5 +44,6 @@ void InitRegistryComponents(Engine::registry &reg) {
     reg.RegisterComponent<Rtype::Client::Component::GameOverState>();
     reg.RegisterComponent<Rtype::Client::Component::FadeOverlay>();
     reg.RegisterComponent<Rtype::Client::Component::GameOverText>();
+    reg.RegisterComponent<Rtype::Client::Component::LeaderboardText>();
 }
 }  // namespace Rtype::Client

--- a/client/game/scenes_management/scenes/GameScene.cpp
+++ b/client/game/scenes_management/scenes/GameScene.cpp
@@ -132,10 +132,11 @@ void GameScene::InitGameOverUI(Engine::registry &reg) {
     reg.AddComponent<Component::FadeOverlay>(
         fade_overlay_entity, Component::FadeOverlay{0.0f});
 
-    // Create "GAME OVER" text (initially invisible with opacity = 0)
+    // Create "GAME OVER" / "VICTORY" text (initially invisible with opacity =
+    // 0)
     auto game_over_text_entity = CreateEntityInScene(reg);
     reg.AddComponent<Component::Transform>(
-        game_over_text_entity, Component::Transform{960.0f, 540.0f, 0.0f, 5.0f,
+        game_over_text_entity, Component::Transform{960.0f, 300.0f, 0.0f, 5.0f,
                                    Component::Transform::CENTER});
     reg.AddComponent<Component::Text>(game_over_text_entity,
         Component::Text{"dogica.ttf", "GAME OVER", 40, LAYER_UI + 101,
@@ -144,6 +145,33 @@ void GameScene::InitGameOverUI(Engine::registry &reg) {
     reg.GetComponent<Component::Text>(game_over_text_entity).opacity = 0.0f;
     reg.AddComponent<Component::GameOverText>(
         game_over_text_entity, Component::GameOverText{false});
+
+    // Create leaderboard title (initially invisible)
+    auto leaderboard_title_entity = CreateEntityInScene(reg);
+    reg.AddComponent<Component::Transform>(
+        leaderboard_title_entity, Component::Transform{960.0f, 200.0f, 0.0f,
+                                      3.0f, Component::Transform::CENTER});
+    reg.AddComponent<Component::Text>(leaderboard_title_entity,
+        Component::Text{"dogica.ttf", "LEADERBOARD", 30, LAYER_UI + 102,
+            Engine::Graphics::Color(255, 255, 255, 255)});
+    reg.GetComponent<Component::Text>(leaderboard_title_entity).opacity = 0.0f;
+    reg.AddComponent<Component::LeaderboardText>(
+        leaderboard_title_entity, Component::LeaderboardText{0, false});
+
+    // Create leaderboard entries (up to 4 players, initially invisible)
+    for (int i = 0; i < 4; ++i) {
+        auto entry_entity = CreateEntityInScene(reg);
+        float y_pos = 320.0f + i * 80.0f;  // Spaced vertically
+        reg.AddComponent<Component::Transform>(
+            entry_entity, Component::Transform{960.0f, y_pos, 0.0f, 2.0f,
+                              Component::Transform::CENTER});
+        reg.AddComponent<Component::Text>(
+            entry_entity, Component::Text{"dogica.ttf", "", 24, LAYER_UI + 102,
+                              Engine::Graphics::Color(255, 255, 255, 255)});
+        reg.GetComponent<Component::Text>(entry_entity).opacity = 0.0f;
+        reg.AddComponent<Component::LeaderboardText>(
+            entry_entity, Component::LeaderboardText{i + 1, false});
+    }
 }
 
 void GameScene::DestroyScene(Engine::registry &reg) {

--- a/client/include/PlayerConst.hpp
+++ b/client/include/PlayerConst.hpp
@@ -2,6 +2,7 @@
 
 namespace Rtype::Client {
 
+// pixels per second
 constexpr const float PLAYER_SPEED_MAX = 350.0f;
 constexpr const float PLAYER_SHOOT_COOLDOWN = 0.2f;
 constexpr const float PLAYER_CHARGE_TIME = 0.5f;

--- a/client/include/components/ScenesComponents.hpp
+++ b/client/include/components/ScenesComponents.hpp
@@ -40,15 +40,21 @@ struct LobbyUI {
 /**
  * @brief Component to track game over state and visual effects.
  *
- * Manages the "GAME OVER" text display and fade transition timing.
+ * Manages the "GAME OVER" / "VICTORY" text display, leaderboard, and
+ * fade transition timing.
  */
 struct GameOverState {
-    bool is_active{false};         // Whether game over sequence is in progress
-    float display_timer{0.0f};     // Time spent displaying "GAME OVER" text
-    float fade_timer{0.0f};        // Time spent fading to lobby
-    bool text_phase{true};         // True = showing text, False = fading
-    static constexpr float kTextDuration = 2.0f;   // 2 seconds "GAME OVER"
-    static constexpr float kFadeDuration = 1.5f;   // 1.5 seconds fade
+    bool is_active{false};      // Whether game over sequence is in progress
+    float display_timer{0.0f};  // Time spent displaying result text
+    float leaderboard_timer{0.0f};  // Time spent displaying leaderboard
+    float fade_timer{0.0f};         // Time spent fading to lobby
+    bool text_phase{true};          // True = showing result text
+    bool leaderboard_phase{false};  // True = showing leaderboard
+    bool is_victory{false};         // True if this client won
+    static constexpr float kTextDuration = 2.0f;  // 2 seconds result text
+    static constexpr float kLeaderboardDuration =
+        5.0f;                                     // 5 seconds leaderboard
+    static constexpr float kFadeDuration = 1.5f;  // 1.5 seconds fade
 };
 
 /**
@@ -59,9 +65,17 @@ struct FadeOverlay {
 };
 
 /**
- * @brief Component to tag the "GAME OVER" text entity.
+ * @brief Component to tag the "GAME OVER" / "VICTORY" text entity.
  */
 struct GameOverText {
+    bool visible{false};
+};
+
+/**
+ * @brief Component to tag leaderboard text entities.
+ */
+struct LeaderboardText {
+    int rank{0};  // 0 = title, 1+ = player entry
     bool visible{false};
 };
 

--- a/server/include/server/PacketSender.hpp
+++ b/server/include/server/PacketSender.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include <boost/asio.hpp>
 
@@ -55,14 +56,19 @@ class PacketSender {
     void SendGameStart();
 
     /**
-     * @brief Send GAME_END packet to all authenticated players
+     * @brief Send GAME_END packet to all authenticated players with
+     * leaderboard
      *
      * RFC Section 5.6: Notifies all players that the game has ended.
-     * Used when all players are dead (game over) or match concludes.
+     * Includes leaderboard data with player names, scores, and rankings.
      *
-     * @param winning_player_id The player who won (0 = draw/game over)
+     * @param winning_player_id The player who won (0 = all lost, 255 = level
+     * complete)
+     * @param game_mode 0 = finite, 1 = infinite
+     * @param leaderboard Vector of player score data for display
      */
-    void SendGameEnd(uint8_t winning_player_id = 0);
+    void SendGameEnd(uint8_t winning_player_id, uint8_t game_mode,
+        const std::vector<network::PlayerScoreData> &leaderboard);
 
     /**
      * @brief Send NOTIFY_CONNECT packet to all authenticated players

--- a/server/src/server/PacketSender.cpp
+++ b/server/src/server/PacketSender.cpp
@@ -101,11 +101,15 @@ void PacketSender::SendGameStart() {
               << std::endl;
 }
 
-void PacketSender::SendGameEnd(uint8_t winning_player_id) {
-    // Build GAME_END packet
+void PacketSender::SendGameEnd(uint8_t winning_player_id, uint8_t game_mode,
+    const std::vector<network::PlayerScoreData> &leaderboard) {
+    // Build GAME_END packet with leaderboard
     network::GameEndPacket game_end;
     game_end.winning_player_id = network::PlayerId{winning_player_id};
-    game_end.reserved = {0, 0, 0};
+    game_end.game_mode = game_mode;
+    game_end.player_count = static_cast<uint8_t>(leaderboard.size());
+    game_end.reserved = {0, 0, 0, 0, 0};
+    game_end.leaderboard = leaderboard;
 
     network::PacketBuffer buffer;
     game_end.Serialize(buffer);
@@ -134,7 +138,8 @@ void PacketSender::SendGameEnd(uint8_t winning_player_id) {
 
     std::cout << "GAME_END packet sent to all authenticated players "
               << "(winning_player_id=" << static_cast<int>(winning_player_id)
-              << ")" << std::endl;
+              << ", game_mode=" << static_cast<int>(game_mode)
+              << ", players=" << leaderboard.size() << ")" << std::endl;
 }
 
 void PacketSender::SendNotifyConnect(

--- a/server/src/server/Server.cpp
+++ b/server/src/server/Server.cpp
@@ -1,5 +1,6 @@
 #include "server/Server.hpp"
 
+#include <algorithm>
 #include <filesystem>
 #include <iostream>
 #include <limits>
@@ -252,9 +253,22 @@ bool Server::AreAllPlayersDead() {
     return false;
 }
 
-void Server::NotifyPlayerDeath() {
+void Server::NotifyPlayerDeath(uint8_t player_id, int final_score) {
     alive_players_--;
-    std::cout << "[Server::NotifyPlayerDeath] Player died. Alive players: "
+
+    // Track death order and final score
+    death_order_counter_++;
+    if (player_records_.find(player_id) != player_records_.end()) {
+        player_records_[player_id].death_order = death_order_counter_;
+        player_records_[player_id].is_alive = false;
+        player_records_[player_id].score = final_score;
+        std::cout << "[Server::NotifyPlayerDeath] Player "
+                  << static_cast<int>(player_id)
+                  << " died (order: " << death_order_counter_
+                  << ", score: " << final_score << ")" << std::endl;
+    }
+
+    std::cout << "[Server::NotifyPlayerDeath] Alive players: "
               << alive_players_ << "/" << total_players_ << std::endl;
 }
 
@@ -285,9 +299,22 @@ void Server::HandlePlayerDisconnect(uint8_t player_id) {
         return;  // Not in game, nothing to do
     }
 
+    // Get score before destroying entity
+    int final_score = 0;
+    auto &player_tags = registry_.GetComponents<Component::PlayerTag>();
+    for (std::size_t i = 0; i < player_tags.size(); ++i) {
+        if (!player_tags.has(i))
+            continue;
+        if (player_tags[i].value().playerNumber ==
+            static_cast<int>(player_id)) {
+            final_score = player_tags[i].value().score;
+            break;
+        }
+    }
+
     // Destroy the player's entity and update tracking only if entity was found
     if (DestroyPlayerEntity(player_id) && alive_players_ > 0) {
-        alive_players_--;
+        NotifyPlayerDeath(player_id, final_score);
     }
 
     std::cout << "[Server::HandlePlayerDisconnect] Player "
@@ -299,7 +326,12 @@ void Server::HandlePlayerDisconnect(uint8_t player_id) {
     if (connection_manager_.GetAuthenticatedCount() == 0 ||
         alive_players_ <= 0) {
         std::cout << "[Server] All players gone! Game Over." << std::endl;
-        packet_sender_.SendGameEnd(0);
+
+        // Build leaderboard and send GAME_END
+        auto leaderboard = BuildLeaderboard(false);  // false = game over
+        uint8_t game_mode =
+            (worldgen_manager_ && !worldgen_manager_->IsEndlessMode()) ? 0 : 1;
+        packet_sender_.SendGameEnd(0, game_mode, leaderboard);
         ResetToLobby();
     }
 }
@@ -322,6 +354,10 @@ void Server::ResetToLobby() {
 
     // Now safe to destroy the system
     worldgen_system_.reset();
+
+    // Reset player tracking
+    player_records_.clear();
+    death_order_counter_ = 0;
 
     // Reset all client ready states
     connection_manager_.ResetAllReadyStates();
@@ -368,6 +404,26 @@ void Server::Update() {
         worldgen_system_->Update(1.0f / 60.0f, 200.0f, registry_);
     }
 
+    // Update alive player scores in records (for accurate leaderboard)
+    auto &player_tags = registry_.GetComponents<Component::PlayerTag>();
+    for (std::size_t i = 0; i < player_tags.size(); ++i) {
+        if (!player_tags.has(i))
+            continue;
+        uint8_t pid =
+            static_cast<uint8_t>(player_tags[i].value().playerNumber);
+        if (player_records_.find(pid) != player_records_.end() &&
+            player_records_[pid].is_alive) {
+            player_records_[pid].score = player_tags[i].value().score;
+        }
+    }
+
+    // Determine game mode
+    bool is_finite = worldgen_manager_ &&
+                     worldgen_manager_->IsLevelComplete() &&
+                     !worldgen_manager_->IsEndlessMode();
+    bool is_endless = !worldgen_manager_ || worldgen_manager_->IsEndlessMode();
+    uint8_t game_mode = is_endless ? 1 : 0;
+
     // Check for level completion (victory condition for finite levels)
     if (worldgen_manager_ && worldgen_manager_->IsLevelComplete() &&
         !worldgen_manager_->IsEndlessMode()) {
@@ -381,13 +437,23 @@ void Server::Update() {
             victory_timer_ += g_frame_delta_ms / 1000.0f;
 
             if (victory_timer_ >= VICTORY_DELAY_SEC) {
-                std::cout << "[Server] Victory delay complete. Sending "
-                             "GAME_END (VICTORY) packet."
-                          << std::endl;
+                std::cout
+                    << "[Server] Victory delay complete. Determining winner..."
+                    << std::endl;
 
-                // Send GAME_END packet with 255 = level complete / victory
-                // Only survivors get the victory screen
-                packet_sender_.SendGameEnd(255);
+                // For finite mode:
+                // - If all players alive, winner is the one with highest score
+                // - If some died, winner is the one who survived longest
+                uint8_t winner_id =
+                    DetermineWinner(true);  // true = victory scenario
+
+                // Build leaderboard with proper winner flags
+                auto leaderboard = BuildLeaderboard(true, winner_id);
+
+                std::cout << "[Server] Sending GAME_END (winner="
+                          << static_cast<int>(winner_id) << ")" << std::endl;
+
+                packet_sender_.SendGameEnd(winner_id, game_mode, leaderboard);
 
                 // Reset server to lobby state
                 ResetToLobby();
@@ -411,13 +477,24 @@ void Server::Update() {
             game_over_timer_ += g_frame_delta_ms / 1000.0f;
 
             if (game_over_timer_ >= GAME_OVER_DELAY_SEC) {
-                std::cout << "[Server] Game over delay complete. Sending "
-                             "GAME_END packet."
+                std::cout << "[Server] Game over delay complete. Determining "
+                             "winner..."
                           << std::endl;
 
-                // Send GAME_END packet to all clients (0 = no winner, game
-                // lost)
-                packet_sender_.SendGameEnd(0);
+                // For game over (all dead):
+                // - In infinite mode: winner is who survived longest (died
+                // last)
+                // - If tie (died same frame), winner is who had more points
+                uint8_t winner_id =
+                    DetermineWinner(false);  // false = all dead scenario
+
+                // Build leaderboard
+                auto leaderboard = BuildLeaderboard(false, winner_id);
+
+                std::cout << "[Server] Sending GAME_END (winner="
+                          << static_cast<int>(winner_id) << ")" << std::endl;
+
+                packet_sender_.SendGameEnd(winner_id, game_mode, leaderboard);
 
                 // Reset server to lobby state
                 ResetToLobby();
@@ -434,6 +511,102 @@ void Server::Update() {
     }
 
     SendSnapshotsToAllClients();
+}
+
+uint8_t Server::DetermineWinner(bool is_victory) {
+    std::vector<std::pair<uint8_t, const PlayerDeathRecord *>> candidates;
+
+    // Collect all player records
+    for (const auto &[pid, record] : player_records_) {
+        candidates.emplace_back(pid, &record);
+    }
+
+    if (candidates.empty()) {
+        return 0;  // No players
+    }
+
+    // For finite mode with victory (level complete):
+    // - If all alive: highest score wins
+    // - If some died: whoever survived longest (lowest death_order among dead,
+    //   or alive) wins, tie-break by score
+    if (is_victory) {
+        // Check if anyone is still alive
+        bool anyone_alive = false;
+        for (const auto &[pid, rec] : candidates) {
+            if (rec->is_alive) {
+                anyone_alive = true;
+                break;
+            }
+        }
+
+        if (anyone_alive) {
+            // All alive survivors: pick highest score among alive
+            uint8_t winner = 0;
+            int best_score = -999999;
+            for (const auto &[pid, rec] : candidates) {
+                if (rec->is_alive && rec->score > best_score) {
+                    best_score = rec->score;
+                    winner = pid;
+                }
+            }
+            return winner;
+        }
+    }
+
+    // For infinite mode or when all dead:
+    // Winner is whoever survived longest (died last = highest death_order)
+    // Tie-break: highest score
+    uint8_t winner = 0;
+    int best_death_order = -1;  // Higher = died later = better
+    int best_score = -999999;
+
+    for (const auto &[pid, rec] : candidates) {
+        int death_order = rec->is_alive ? 99999 : rec->death_order;
+
+        if (death_order > best_death_order ||
+            (death_order == best_death_order && rec->score > best_score)) {
+            best_death_order = death_order;
+            best_score = rec->score;
+            winner = pid;
+        }
+    }
+
+    return winner;
+}
+
+std::vector<network::PlayerScoreData> Server::BuildLeaderboard(
+    bool is_victory, uint8_t winner_id) {
+    std::vector<network::PlayerScoreData> leaderboard;
+
+    for (const auto &[pid, record] : player_records_) {
+        network::PlayerScoreData entry;
+        entry.player_id = network::PlayerId{pid};
+        entry.SetName(record.username);
+        entry.score = static_cast<uint32_t>(std::max(0, record.score));
+        entry.death_order = static_cast<uint8_t>(record.death_order);
+        entry.is_winner = (pid == winner_id) ? 1 : 0;
+        leaderboard.push_back(entry);
+    }
+
+    // Sort by: 1) is_winner desc, 2) death_order asc (0=alive first), 3) score
+    // desc
+    std::sort(leaderboard.begin(), leaderboard.end(),
+        [](const network::PlayerScoreData &a,
+            const network::PlayerScoreData &b) {
+            if (a.is_winner != b.is_winner)
+                return a.is_winner > b.is_winner;
+            // death_order 0 = alive, higher = died later
+            // We want alive first, then died last (highest death_order)
+            if (a.death_order == 0 && b.death_order != 0)
+                return true;
+            if (b.death_order == 0 && a.death_order != 0)
+                return false;
+            if (a.death_order != b.death_order)
+                return a.death_order > b.death_order;  // Died later = better
+            return a.score > b.score;
+        });
+
+    return leaderboard;
 }
 
 Engine::registry &Server::GetRegistry() {

--- a/server/src/server/ServerSetupGame.cpp
+++ b/server/src/server/ServerSetupGame.cpp
@@ -51,9 +51,11 @@ void Server::SetupEntitiesGame() {
     // Setup factory enemy info map
     FactoryActors::GetInstance().InitializeEnemyInfoMap("data/");
 
-    // Reset player trackingd q
+    // Reset player tracking
     total_players_ = 0;
     alive_players_ = 0;
+    player_records_.clear();
+    death_order_counter_ = 0;
 
     for (const auto &pair : connection_manager_.GetClients()) {
         const auto &client = pair.second;
@@ -74,6 +76,15 @@ void Server::SetupEntitiesGame() {
         auto &network_id =
             registry_.GetComponent<Component::NetworkId>(entity);
         network_id.id = static_cast<uint32_t>(client.player_id_);
+
+        // Initialize player death record for leaderboard tracking
+        PlayerDeathRecord record;
+        record.player_id = client.player_id_;
+        record.username = client.username_;
+        record.score = 0;
+        record.death_order = 0;  // 0 = alive
+        record.is_alive = true;
+        player_records_[client.player_id_] = record;
 
         // Track player count
         total_players_++;

--- a/server/src/server/Systems/HealthDeductionSystem.cpp
+++ b/server/src/server/Systems/HealthDeductionSystem.cpp
@@ -32,8 +32,13 @@ void DeathHandling(Engine::registry &reg,
                   << std::endl;
         auto &playerTag = reg.GetComponents<Component::PlayerTag>()[i].value();
         playerTag.score -= 250;  // Penalize score on death
+
+        // Get player info for death tracking
+        uint8_t player_id = static_cast<uint8_t>(playerTag.playerNumber);
+        int final_score = playerTag.score;
+
         if (Server::GetInstance()) {
-            Server::GetInstance()->NotifyPlayerDeath();
+            Server::GetInstance()->NotifyPlayerDeath(player_id, final_score);
         }
     }
 

--- a/server/src/server/Systems/ObstacleCollisionSystem.cpp
+++ b/server/src/server/Systems/ObstacleCollisionSystem.cpp
@@ -40,9 +40,19 @@ void HandleCrushDeath(
     std::cout << "[ObstacleCollision] Player at index " << i << " was CRUSHED!"
               << std::endl;
 
-    // Notify server about player death
+    // Get player info before removing components
+    uint8_t player_id = 0;
+    int final_score = 0;
+    auto &player_tags = reg.GetComponents<Component::PlayerTag>();
+    if (player_tags.has(i)) {
+        auto &tag = player_tags[i].value();
+        player_id = static_cast<uint8_t>(tag.playerNumber);
+        final_score = tag.score - 250;  // Death penalty
+    }
+
+    // Notify server about player death with ID and score
     if (Server::GetInstance()) {
-        Server::GetInstance()->NotifyPlayerDeath();
+        Server::GetInstance()->NotifyPlayerDeath(player_id, final_score);
     }
 
     // Get fresh references after potential resizes


### PR DESCRIPTION
## 🚀 Pull Request Summary

Milestone: 7

---

## 🧩 Type of Change

Select all relevant options:

- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] 🧪 Tests
- [ ] 🔧 Tooling / CI
- [ ] 🚀 Performance
- [ ] Other (please describe)

---

## 📦 Changes Included

List the main changes made in this PR:

- **Victory/Losing Logic**: Implemented win conditions for finite and infinite game modes
  - **Finite mode**: Longest survivor wins; if all alive at end, highest score wins
  - **Infinite mode**: Longest survivor wins; tie-break by score for same-frame deaths
- **Leaderboard System**: Added 5-second leaderboard display showing all players, scores, and status
- **Enhanced GAME_END Packet**: Extended packet structure to include leaderboard data (PlayerScoreData)
- **Server Death Tracking**: Added player death order tracking with PlayerDeathRecord system
- **Server Victory Logic**: Implemented DetermineWinner() and BuildLeaderboard() methods
- **Client UI**: Created leaderboard text entities with colored status indicators ([WINNER], [ALIVE], grayed out)
- **GameOverSystem Rewrite**: Multi-phase system (result text → leaderboard → menu transition)
- **Network Protocol**: Updated HandleGameEnd to parse extended packet format with leaderboard entries

---

## 🧪 How to Test

Describe how reviewers can test your changes:

1. Build the project (`./scripts/build.sh` or `cmake --build build`)
2. Start the server: `./build/server/r-type_server 50000`
3. Start 2-4 clients: `./build/client/r-type_client <username> 127.0.0.1 50000`
4. All players ready up
5. Play until game ends (all players die or level completes)
6. Observe the sequence:
   - "VICTORY!" (green) or "GAME OVER" (red) text appears for 2 seconds
   - Leaderboard appears for 5 seconds showing all players ranked by survival time and score
   - Automatic transition back to main menu

**Test Scenarios:**
- **Finite mode, all alive**: Highest score wins
- **Finite mode, some deaths**: Longest survivor wins
- **Infinite mode**: Longest survivor wins (tie-break by score)
- **Same-frame deaths**: Players dying in same WGF frame tie, winner determined by score

---

## 🗂️ Related Areas

Which part of the project does this PR affect?

- [ ] area/docs
- [x] area/server
- [x] area/client
- [x] area/engine
- [ ] area/tests

---

## 🔍 Checklist Before Requesting Review

Please confirm the following items are done:

- [x] My commits follow the **Gitmoji + English commit message** convention
- [x] My branch name follows the required format (`feature/XX-name`)
- [ ] I have linked the PR to an Issue (`Closes #XX`)
- [x] I ran and passed **all Git hooks**
- [ ] I added or updated documentation if needed
- [ ] I added or updated tests if needed
- [x] The code builds without errors
- [x] I performed manual testing
- [ ] CI passes all checks (build + tests + formatting)

---

## 📸 Screenshots / Logs (if applicable)

Add images, console logs, videos, or anything helpful for reviewers.

**Expected Console Output:**
```
[GameOverSystem] VICTORY! Showing result text.
[GameOverSystem] Result text complete. Showing leaderboard.
[GameOverSystem] Leaderboard complete. Transitioning to lobby.
```

**Leaderboard Display Example:**
```
LEADERBOARD (yellow)
1. Player1 - 1500 [WINNER] (green)
2. Player2 - 1200 [ALIVE] (white)
3. Player3 - 800 (gray)
4. Player4 - 500 (gray)
```

---

## 👀 Reviewer Notes

Anything you want reviewers to pay special attention to?

- **Packet Format**: Review the extended GAME_END packet structure (PlayerScoreData with 39 bytes per entry)
- **Death Tracking**: Verify the death_order_counter logic correctly handles same-frame deaths
- **Victory Logic**: Check DetermineWinner() implementation matches specification for finite vs infinite modes
- **Client Timing**: Ensure 5-second leaderboard display feels appropriate (configurable via kLeaderboardDuration)
- **Missing Includes**: Added `<utility>` and `<vector>` includes to satisfy cpplint requirements
- **Thread Safety**: GetLeaderboard() uses mutex to protect leaderboard vector access

---

## 🔧 Modified Files (14 total)

**Server:**
- `server/include/server/Packets.hpp` - Extended GameEndPacket
- `server/include/server/PacketSender.hpp` - Updated SendGameEnd signature
- `server/include/server/Server.hpp` - Added death tracking structures
- `server/src/server/Server.cpp` - Victory logic implementation
- `server/src/server/PacketSender.cpp` - Updated packet sending
- `server/src/server/ServerSetupGame.cpp` - Initialize player records
- `server/src/server/Systems/HealthDeductionSystem.cpp` - Pass death data
- `server/src/server/Systems/ObstacleCollisionSystem.cpp` - Pass death data

**Client:**
- `client/network/Network.hpp` - Added leaderboard parsing
- `client/network/Network.cpp` - HandleGameEnd update
- `client/include/components/ScenesComponents.hpp` - LeaderboardText component
- `client/game/scenes_management/scenes/GameScene.cpp` - Create leaderboard UI
- `client/engine/InitRegistryComponent.cpp` - Register LeaderboardText
- `client/engine/systems/systems_functions/GameOverSystem.cpp` - Complete rewrite
